### PR TITLE
fix giscus against dynamic document.title

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <!-- responsive -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 
-  <title>&nbsp;</title>
+  <title>&lrm;</title>
 
   <!-- favicon -->
   <link rel="icon" href="favicon.ico">
@@ -44,10 +44,7 @@
       <div class="main-page" id="main-page"></div>
 
       <!-- comment system -->
-      <div id="comment-system">
-        <!-- for opt.3 giscus only -->
-        <div class="giscus"></div>
-      </div>
+      <div id="comment-system"></div>
     </div>
   </div>
 </div>
@@ -81,29 +78,9 @@ var _hmt = _hmt || [];
 (function() {
   var hm = document.createElement("script");
   hm.src = "https://hm.baidu.com/hm.js?d3ca43076bfa5314312ab46599d87c62";
-  var s = document.getElementsByTagName("script")[0]; 
+  var s = document.getElementsByTagName("script")[0];
   s.parentNode.insertBefore(hm, s);
 })();
-</script>
-
-
-<!-- comment system -->
-<!-- opt.3 giscus -->
-<!-- https://giscus.app/ -->
-<script src="https://giscus.app/client.js"
-        data-repo="zhanzengyu/blog"
-        data-repo-id="R_kgDOIK5_vA"
-        data-category="Announcements"
-        data-category-id="DIC_kwDOIK5_vM4CR4TQ"
-        data-mapping="title"
-        data-strict="0"
-        data-reactions-enabled="1"
-        data-emit-metadata="0"
-        data-input-position="bottom"
-        data-theme="light"
-        data-lang="zh-CN"
-        crossorigin="anonymous"
-        async>
 </script>
 
 </body>

--- a/p/aboutme.md
+++ b/p/aboutme.md
@@ -11,4 +11,5 @@
 - 邮箱：nesger.zhan@gmail.com
 
 ### 微信公众号
-![](./images/wechat.png)
+
+<img width="500" src="images/wechat.png">

--- a/vendor/blog.js
+++ b/vendor/blog.js
@@ -242,35 +242,25 @@
     return navTitle
   }
 
-  // opt.1 disqus
-  // https://disqus.com/admin/install/platforms/universalcode/
-  function disqus(shortName, title, id) {
-    window.disqus_shortname = shortName
-    window.disqus_title = title
-    window.disqus_identifier = id
-    window.disqus_url = location.href
-    $('<div>').attr({ id: 'disqus_thread' }).appendTo('#comment-system')
-    $('<script>').attr({
-      src: 'https://' + shortName + '.disqus.com/embed.js',
-      'data-timestamp': +new Date(),
+  // https://giscus.app/
+  function giscus(attrs) {
+    $('<div>').addClass('giscus').appendTo('#comment-system')
+    var dest = {
+      src: 'https://giscus.app/client.js',
+      'data-mapping': 'title', // mapping='title' is required for silent
+      'data-strict': '0',
+      'data-reactions-enabled': '1',
+      'data-emit-metadata': '0',
+      'data-input-position': 'bottom',
+      'data-theme': 'light', // silent doesn't support darkmode now
+      crossorigin: 'anonymous',
       async: true
-    }).appendTo('head')
-  }
-  // opt.2 cusdis
-  // https://cusdis.com/doc#/advanced/sdk?id=js-sdk
-  function cusdis(host, appId, title, id) {
-    $('<div>').attr({
-      id: 'cusdis_thread',
-      'data-host': host,
-      'data-app-id': appId,
-      'data-page-id': id,
-      'data-page-url': location.href,
-      'data-page-title': title
-    }).appendTo('#comment-system')
-    $('<script>').attr({
-      src: 'https://cusdis.com/js/cusdis.umd.js',
-      async: true
-    }).appendTo('head')
+    }
+    Object.keys(attrs).forEach(function (k) { dest[k] = attrs[k] })
+    // notice: $('<script>') not working here
+    var script = document.createElement('script')
+    Object.keys(dest).forEach(function (k) { script.setAttribute(k, dest[k]) })
+    document.body.appendChild(script)
   }
 
   config()
@@ -283,18 +273,13 @@
 
   function comments() {
     //// Optional comment system
-    // opt.1 disqus (not recommended in China due to the GFW)
-    // var dqsShortName = 'silent-blog'
-    // disqus(dqsShortName, mainTitle, mainPage)
-
-    // opt.2 cusdis
-    // var cdsHost = 'https://cusdis.com'
-    // var cdsAppId = '3ab3a14f-bcb2-4a6f-b984-742a15463f80'
-    // cusdis(cdsHost, cdsAppId, mainTitle, mainPage)
-
-    // opt.3 giscus
-    // giscus logic should be added directly to html
-    // to make it work instead, see index.html
+    giscus({
+      'data-repo': 'zhanzengyu/blog',
+      'data-repo-id': 'R_kgDOIK5_vA',
+      'data-category': 'Announcements',
+      'data-category-id': 'DIC_kwDOIK5_vM4CR4TQ',
+      'data-lang': 'zh-CN'
+    })
   }
 
   function shares() {


### PR DESCRIPTION
1. 修复 首屏title 初始化过程中 应确保为空白
2. 修复 silent动态document.title 对 giscus评论插件 的适配
3. aboutme中的 二维码图片 最大宽度减小 PC上展示不会过大显得突兀（移动端不影响）

before:

<img width="1679" alt="image" src="https://user-images.githubusercontent.com/6647633/194886502-3aa7f8bc-0013-404f-b68e-df608a365b3a.png">

after:

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/6647633/194886440-93705388-a3c4-4a33-8e57-5f0d07866f8a.png">

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/6647633/194886632-50236c1a-e5d8-4111-b78b-9092eb3ad43f.png">
