### PR TITLE
fix: avoid cache never expires

### DIFF
--- a/vendor/blog.js
+++ b/vendor/blog.js
@@ -45,6 +45,10 @@
     var url = pageBase + pageId + pageExt
     $.ajax({
       url: url,
+      headers: {
+        // avoid cache never expires in case of missing cache-policy from server
+        'Cache-Control': 'max-age=1', // 1min
+      },
       error: function (err) {
         if (isMain && pageId !== mainPageId) return
 


### PR DESCRIPTION
- [x] 服务端缓存策略已优化，从默认缺省改为max-age=1min
- [x] 本PR：ajax请求md时，主动添加max-age=1min
- [ ] 已经受影响的用户缓存无法消除（过期时间不确定，可能很长），用户只能手动刷新才能解决